### PR TITLE
feat: 给水印目录添加漫画名，以区分不同的漫画

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -7,6 +7,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    MangaDirIndicator: typeof import('./src/components/MangaDirIndicator.vue')['default']
     NButton: typeof import('naive-ui')['NButton']
     NInput: typeof import('naive-ui')['NInput']
     NMessageProvider: typeof import('naive-ui')['NMessageProvider']

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,8 @@
 #![warn(clippy::unwrap_used)]
 
 use crate::commands::{
-    generate_background, get_jpg_image_infos, get_manga_dir_data, open_image, remove_watermark,
+    generate_background, get_background_dir_abs_path, get_background_dir_relative_path,
+    get_jpg_image_infos, get_manga_dir_data, open_image, remove_watermark,
     show_path_in_file_manager,
 };
 use crate::events::{
@@ -17,6 +18,7 @@ mod errors;
 mod events;
 mod extensions;
 mod types;
+mod utils;
 mod watermark;
 
 #[allow(clippy::unwrap_used)]
@@ -30,6 +32,8 @@ fn main() {
                 get_manga_dir_data,
                 get_jpg_image_infos,
                 show_path_in_file_manager,
+                get_background_dir_relative_path,
+                get_background_dir_abs_path,
             ])
             .events(tauri_specta::collect_events![
                 RemoveWatermarkStartEvent,

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,0 +1,28 @@
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+pub fn get_background_dir_relative_path(
+    manga_dir: &str,
+    width: u32,
+    height: u32,
+) -> anyhow::Result<PathBuf> {
+    let manga_dir_name = Path::new(manga_dir)
+        .file_name()
+        .ok_or(anyhow::anyhow!("获取漫画目录名失败"))?
+        .to_str()
+        .ok_or(anyhow::anyhow!("漫画目录名包含非UTF-8字符"))?;
+    let relative_path = format!("背景水印图/{manga_dir_name}{width}x{height}");
+    Ok(PathBuf::from(relative_path))
+}
+
+pub fn get_background_dir_abs_path(
+    app: &AppHandle,
+    manga_dir: &str,
+    width: u32,
+    height: u32,
+) -> anyhow::Result<PathBuf> {
+    let resource_dir = app.path().resource_dir()?;
+    let relative_path = get_background_dir_relative_path(manga_dir, width, height)?;
+    let abs_path = resource_dir.join(relative_path);
+    Ok(abs_path)
+}

--- a/src-tauri/src/watermark.rs
+++ b/src-tauri/src/watermark.rs
@@ -22,6 +22,10 @@ pub fn generate_background(
     width: u32,
     height: u32,
 ) -> anyhow::Result<CommandResponse<()>> {
+    // 保证输出目录存在
+    std::fs::create_dir_all(output_dir)
+        .context(format!("创建目录 {} 失败", output_dir.display()))?;
+    // 收集尺寸符合width和height的图片的路径
     let image_paths = create_image_paths(manga_dir, width, height);
     // 用于记录是否找到了黑色背景和白色背景的水印图片
     let black_status: Mutex<Option<()>> = Mutex::new(None);
@@ -52,8 +56,6 @@ pub fn generate_background(
                 *pixel = color;
             }
         }
-        std::fs::create_dir_all(output_dir)
-            .context(format!("创建目录 {} 失败", output_dir.display()))?;
         let filename = if is_black { "black.png" } else { "white.png" };
         let output_path = output_dir.join(filename);
         // 保存黑色背景或白色背景的水印图片
@@ -324,7 +326,6 @@ fn is_black_background(img: &RgbImage, rect_data: &RectData) -> Option<bool> {
 #[allow(clippy::cast_lossless)]
 #[allow(clippy::cast_sign_loss)]
 fn remove_image_watermark(black: &RgbImage, white: &RgbImage, img: &mut RgbImage) {
-    // TODO: 处理图片大小不一致的情况
     if img.width() != white.width() || img.height() != white.height() {
         return;
     }

--- a/src/AppContent.vue
+++ b/src/AppContent.vue
@@ -7,6 +7,8 @@ import WatermarkCropper from "./components/WatermarkCropper.vue";
 import {path} from "@tauri-apps/api";
 import {BaseDirectory, exists} from "@tauri-apps/plugin-fs";
 import RemoveProgress from "./components/RemoveProgress.vue";
+import {showPathInFileManager} from "./utils.ts";
+import MangaDirIndicator from "./components/MangaDirIndicator.vue";
 
 const notification = useNotification();
 const message = useMessage();
@@ -134,15 +136,8 @@ async function selectOutputDir() {
   outputDir.value = dirPath;
 }
 
-async function showPathInFileManager(path: string | undefined) {
-  if (path === undefined) {
-    return;
-  }
-  await commands.showPathInFileManager(path);
-}
-
 async function loadBackground() {
-  const tasks = [];
+  const tasks: Promise<void>[] = [];
   for (const mangaDirData of mangaDirDataList.value) {
     const load = async (isBlack: boolean) => {
       const filename = isBlack ? "black.png" : "white.png";
@@ -174,12 +169,6 @@ async function loadBackground() {
     tasks.push(load(true), load(false));
   }
   await Promise.all(tasks);
-}
-
-function showCropper(width: number, height: number) {
-  cropperShowing.value = true;
-  cropperWidth.value = width;
-  cropperHeight.value = height;
 }
 
 async function test() {
@@ -214,34 +203,14 @@ async function test() {
       <n-button :disabled="!outputDirExist" @click="showPathInFileManager(outputDir)">打开目录</n-button>
     </div>
 
-    <div v-if="mangaDirExist">
-      漫画目录的图片:
-      <div v-if="!imagesExist">
-        <span>没有图片</span>
-      </div>
-      <div v-else v-for="dirData in mangaDirDataList" :key="dirData.count">
-        <span>
-          尺寸({{ dirData.width }}x{{ dirData.height }})共有{{ dirData.count }} 张
-          <n-button size="tiny"
-                    :disabled="dirData.blackBackground===null"
-                    @click="showPathInFileManager(dirData.blackBackground?.info.path)">
-            黑色
-          </n-button>
-          <n-button size="tiny"
-                    :disabled="dirData.whiteBackground===null"
-                    @click="showPathInFileManager(dirData.whiteBackground?.info.path)">
-            白色
-          </n-button>
-          <n-button size="tiny" @click="showCropper(dirData.width, dirData.height)">手动截取水印</n-button>
-          <span v-if="dirData.blackBackground!==null&&dirData.whiteBackground!==null">✅将被去除水印</span>
-          <span v-else-if="dirData.blackBackground===null&&dirData.whiteBackground===null">
-            ❌将被复制，因为缺少黑色和白色背景水印图
-          </span>
-          <span v-else-if="dirData.blackBackground===null">❌将被复制，因为缺少黑色背景水印图</span>
-          <span v-else-if="dirData.whiteBackground===null">❌将被复制，因为缺少白色背景水印图</span>
-        </span>
-      </div>
-    </div>
+    <manga-dir-indicator :load-background="loadBackground"
+                         :manga-dir-data-list="mangaDirDataList"
+                         :output-dir-exist="outputDirExist"
+                         :manga-dir-exist="mangaDirExist"
+                         :images-exist="imagesExist"
+                         v-model:cropper-showing="cropperShowing"
+                         v-model:cropper-width="cropperWidth"
+                         v-model:cropper-height="cropperHeight"/>
 
     <n-button :disabled="removeWatermarkButtonDisabled"
               type="primary"

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -41,6 +41,22 @@ return await TAURI_INVOKE("get_jpg_image_infos", { mangaDir });
 },
 async showPathInFileManager(path: string) : Promise<void> {
 await TAURI_INVOKE("show_path_in_file_manager", { path });
+},
+async getBackgroundDirRelativePath(mangaDir: string, width: number, height: number) : Promise<Result<CommandResponse<string>, CommandError>> {
+try {
+    return { status: "ok", data: await TAURI_INVOKE("get_background_dir_relative_path", { mangaDir, width, height }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getBackgroundDirAbsPath(mangaDir: string, width: number, height: number) : Promise<Result<CommandResponse<string>, CommandError>> {
+try {
+    return { status: "ok", data: await TAURI_INVOKE("get_background_dir_abs_path", { mangaDir, width, height }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/components/MangaDirIndicator.vue
+++ b/src/components/MangaDirIndicator.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import {MangaDirData} from "../bindings.ts";
+import {showPathInFileManager} from "../utils.ts";
+
+defineProps<{
+  mangaDirExist: boolean,
+  outputDirExist: boolean,
+  imagesExist: boolean,
+  mangaDirDataList: MangaDirData[],
+  loadBackground: () => Promise<void>,
+}>();
+
+const cropperShowing = defineModel<boolean>("cropperShowing", {required: true});
+const cropperWidth = defineModel<number>("cropperWidth", {required: true});
+const cropperHeight = defineModel<number>("cropperHeight", {required: true});
+
+function showCropper(width: number, height: number) {
+  cropperShowing.value = true;
+  cropperWidth.value = width;
+  cropperHeight.value = height;
+}
+
+</script>
+
+<template>
+  <div v-if="mangaDirExist">
+    漫画目录的图片:
+    <div v-if="!imagesExist">
+      <span>没有图片</span>
+    </div>
+    <div v-else v-for="dirData in mangaDirDataList" :key="dirData.count">
+        <span>
+          尺寸({{ dirData.width }}x{{ dirData.height }})共有{{ dirData.count }} 张
+          <n-button size="tiny"
+                    :disabled="dirData.blackBackground===null"
+                    @click="showPathInFileManager(dirData.blackBackground?.info.path)">
+            黑色
+          </n-button>
+          <n-button size="tiny"
+                    :disabled="dirData.whiteBackground===null"
+                    @click="showPathInFileManager(dirData.whiteBackground?.info.path)">
+            白色
+          </n-button>
+          <n-button size="tiny" @click="showCropper(dirData.width, dirData.height)">手动截取水印</n-button>
+          <span v-if="dirData.blackBackground!==null&&dirData.whiteBackground!==null">✅将被去除水印</span>
+          <span v-else-if="dirData.blackBackground===null&&dirData.whiteBackground===null">
+            ❌将被复制，因为缺少黑色和白色背景水印图
+          </span>
+          <span v-else-if="dirData.blackBackground===null">❌将被复制，因为缺少黑色背景水印图</span>
+          <span v-else-if="dirData.whiteBackground===null">❌将被复制，因为缺少白色背景水印图</span>
+        </span>
+    </div>
+  </div>
+</template>

--- a/src/components/MangaDirIndicator.vue
+++ b/src/components/MangaDirIndicator.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
 import {MangaDirData} from "../bindings.ts";
-import {showPathInFileManager} from "../utils.ts";
+import {autoGenerateBackground, getBackgroundDirAbsPath, showPathInFileManager} from "../utils.ts";
+import {useMessage, useNotification} from "naive-ui";
+import {nextTick} from "vue";
 
-defineProps<{
+const notification = useNotification();
+const message = useMessage();
+
+const prop = defineProps<{
+  mangaDir: string | undefined,
   mangaDirExist: boolean,
   outputDirExist: boolean,
   imagesExist: boolean,
   mangaDirDataList: MangaDirData[],
   loadBackground: () => Promise<void>,
+  autoGenerateAll: () => Promise<void>,
 }>();
 
 const cropperShowing = defineModel<boolean>("cropperShowing", {required: true});
@@ -20,26 +27,62 @@ function showCropper(width: number, height: number) {
   cropperHeight.value = height;
 }
 
+async function showBackgroundDirInFileManager(mangaDirData: MangaDirData) {
+  if (prop.mangaDir === undefined) {
+    return;
+  }
+  const backgroundDirAbsPath = await getBackgroundDirAbsPath(prop.mangaDir, mangaDirData.width, mangaDirData.height, notification);
+  if (backgroundDirAbsPath === null) {
+    return;
+  }
+  await showPathInFileManager(backgroundDirAbsPath);
+}
+
+async function autoGenerateSingle(width: number, height: number) {
+  if (prop.mangaDir === undefined) {
+    return;
+  }
+  const autoGeneratingMessage = message.loading(`尝试自动生成背景水印图(${width}x${height})`, {duration: 0});
+  const success = await autoGenerateBackground(prop.mangaDir, width, height, notification);
+  if (success) {
+    message.success(`自动生成背景水印图(${width}x${height})成功`);
+  }
+  await prop.loadBackground();
+  await nextTick(autoGeneratingMessage.destroy);
+}
+
 </script>
 
 <template>
   <div v-if="mangaDirExist">
-    漫画目录的图片:
+    <div class="flex gap-col-3">
+      <div>漫画目录的图片:</div>
+      <n-button size="tiny"
+                type="primary"
+                secondary
+                @click="loadBackground">
+        重新扫描水印目录
+      </n-button>
+      <n-button size="tiny"
+                type="primary"
+                secondary
+                @click="autoGenerateAll">
+        全部重试自动生成
+      </n-button>
+    </div>
     <div v-if="!imagesExist">
       <span>没有图片</span>
     </div>
     <div v-else v-for="dirData in mangaDirDataList" :key="dirData.count">
-        <span>
+        <span class="flex flex-justify-b">
           尺寸({{ dirData.width }}x{{ dirData.height }})共有{{ dirData.count }} 张
           <n-button size="tiny"
-                    :disabled="dirData.blackBackground===null"
-                    @click="showPathInFileManager(dirData.blackBackground?.info.path)">
-            黑色
+                    @click="showBackgroundDirInFileManager(dirData)">
+            水印目录
           </n-button>
           <n-button size="tiny"
-                    :disabled="dirData.whiteBackground===null"
-                    @click="showPathInFileManager(dirData.whiteBackground?.info.path)">
-            白色
+                    @click="autoGenerateSingle(dirData.width, dirData.height)">
+            尝试自动生成
           </n-button>
           <n-button size="tiny" @click="showCropper(dirData.width, dirData.height)">手动截取水印</n-button>
           <span v-if="dirData.blackBackground!==null&&dirData.whiteBackground!==null">✅将被去除水印</span>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+import {commands} from "./bindings.ts";
+
+export async function showPathInFileManager(path: string | undefined) {
+    if (path === undefined) {
+        return;
+    }
+    await commands.showPathInFileManager(path);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,58 @@
 import {commands} from "./bindings.ts";
+import {NotificationApiInjection} from "naive-ui/es/notification/src/NotificationProvider";
 
 export async function showPathInFileManager(path: string | undefined) {
     if (path === undefined) {
         return;
     }
     await commands.showPathInFileManager(path);
+}
+
+export async function getBackgroundDirRelativePath(mangaDir: string, width: number, height: number, notification: NotificationApiInjection): Promise<string | null> {
+    const dirResult = await commands.getBackgroundDirRelativePath(mangaDir, width, height);
+    if (dirResult.status === "error") {
+        notification.error({title: "获取背景水印图相对路径失败", description: dirResult.error});
+        return null;
+    }
+    const dirResponse = dirResult.data;
+    if (dirResponse.code !== 0) {
+        notification.warning({title: "获取背景水印图相对路径失败", description: dirResponse.msg});
+        return null;
+    }
+    return dirResponse.data;
+}
+
+export async function getBackgroundDirAbsPath(mangaDir: string, width: number, height: number, notification: NotificationApiInjection): Promise<string | null> {
+    const dirResult = await commands.getBackgroundDirAbsPath(mangaDir, width, height);
+    if (dirResult.status === "error") {
+        notification.error({title: "获取背景水印图绝对路径失败", description: dirResult.error});
+        return null;
+    }
+    const dirResponse = dirResult.data;
+    if (dirResponse.code !== 0) {
+        notification.warning({title: "获取背景水印图绝对路径失败", description: dirResponse.msg});
+        return null;
+    }
+    return dirResponse.data;
+}
+
+export async function autoGenerateBackground(mangaDir: string, width: number, height: number, notification: NotificationApiInjection): Promise<boolean> {
+    const generateResult = await commands.generateBackground(mangaDir, null, width, height);
+    if (generateResult.status === "error") {
+        notification.error({
+            title: `自动生成背景水印图(${width}x${height})失败`,
+            description: generateResult.error
+        });
+        return false;
+    }
+    const response = generateResult.data;
+    if (response.code !== 0) {
+        notification.warning({
+            title: `自动生成背景水印图(${width}x${height})失败`,
+            description: response.msg,
+            content: "请尝试手动截取水印",
+        });
+        return false;
+    }
+    return true;
 }


### PR DESCRIPTION
不同的漫画可能存在尺寸相同但是水印不同的情况

假设漫画A和B尺寸相同，都为(1000X2000)
去除漫画A的水印后，将留下1000X2000的背景水印图目录
因此之后再处理漫画B，漫画B的自动生成将被跳过，然后沿用A的背景水印图，导致去水印失败

这个PR给水印目录添加漫画名，以解决这个问题
另外还添加了一些实用的按钮
解决这个issue #4 